### PR TITLE
resurrect camera_device

### DIFF
--- a/cameraserver.te
+++ b/cameraserver.te
@@ -15,6 +15,7 @@ allow cameraserver camera_data_file:file create_file_perms;
 
 allow cameraserver video_device:dir r_dir_perms;
 allow cameraserver video_device:chr_file rw_file_perms;
+allow cameraserver camera_device:chr_file rw_file_perms;
 allow cameraserver ion_device:chr_file rw_file_perms;
 
 allow cameraserver appops_service:service_manager find;

--- a/file_contexts
+++ b/file_contexts
@@ -61,7 +61,7 @@
 /dev/block/ram[0-9]*	u:object_r:ram_device:s0
 /dev/block/zram[0-9]*	u:object_r:ram_device:s0
 /dev/bus/usb(.*)?       u:object_r:usb_device:s0
-/dev/cam		u:object_r:video_device:s0
+/dev/cam		u:object_r:camera_device:s0
 /dev/console		u:object_r:console_device:s0
 /dev/cpuctl(/.*)?	u:object_r:cpuctl_device:s0
 /dev/device-mapper	u:object_r:dm_device:s0


### PR DESCRIPTION
(cherry picked from commit e8a53dff5b769de2b6c218877cc59595771ca5be)

With the breakup of mediaserver, distinguishing between
camera_device and video_device is meaningful. Only grant
cameraserver access to camera_device.

Bug: 28359909
Change-Id: I0ae12f87bac8a5c912f0a693d1d56a8d5af7f3f3
