### PR TITLE
allow platform_app to use nfc_service for NFC tile

### DIFF
--- a/prebuilts/api/30.0/private/platform_app.te
+++ b/prebuilts/api/30.0/private/platform_app.te
@@ -59,6 +59,7 @@ allow platform_app mediaserver_service:service_manager find;
 allow platform_app mediametrics_service:service_manager find;
 allow platform_app mediaextractor_service:service_manager find;
 allow platform_app mediadrmserver_service:service_manager find;
+allow platform_app nfc_service:service_manager find;
 allow platform_app persistent_data_block_service:service_manager find;
 allow platform_app radio_service:service_manager find;
 allow platform_app thermal_service:service_manager find;

--- a/private/platform_app.te
+++ b/private/platform_app.te
@@ -59,6 +59,7 @@ allow platform_app mediaserver_service:service_manager find;
 allow platform_app mediametrics_service:service_manager find;
 allow platform_app mediaextractor_service:service_manager find;
 allow platform_app mediadrmserver_service:service_manager find;
+allow platform_app nfc_service:service_manager find;
 allow platform_app persistent_data_block_service:service_manager find;
 allow platform_app radio_service:service_manager find;
 allow platform_app thermal_service:service_manager find;


### PR DESCRIPTION
This is already permitted for priv_app and even untrusted_app.