### PR TITLE
split out untrusted base app domains

### DIFF
--- a/prebuilts/api/30.0/private/app_neverallows.te
+++ b/prebuilts/api/30.0/private/app_neverallows.te
@@ -13,6 +13,10 @@ define(`all_untrusted_apps',`{
   untrusted_app_27
   untrusted_app_29
   untrusted_app_all
+  untrusted_base_app
+  untrusted_base_app_25
+  untrusted_base_app_27
+  untrusted_base_app_29
 }')
 # Receive or send uevent messages.
 neverallow all_untrusted_apps domain:netlink_kobject_uevent_socket *;
@@ -56,7 +60,9 @@ neverallow all_untrusted_apps app_exec_data_file:file
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
   -runas_app
 } { app_data_file privapp_data_file }:file execute_no_trans;
 
@@ -66,7 +72,9 @@ neverallow {
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
 } dex2oat_exec:file no_x_file_perms;
 
 # Do not allow untrusted apps to be assigned mlstrustedsubject.
@@ -118,8 +126,11 @@ neverallow all_untrusted_apps *:{
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
   -untrusted_app_29
+  -untrusted_base_app_29
 } domain:netlink_route_socket { bind nlmsg_readpriv };
 
 # Do not allow untrusted apps access to /cache
@@ -245,7 +256,7 @@ neverallow all_untrusted_apps selinuxfs:file no_rw_file_perms;
 # b/33214085 b/33814662 b/33791054 b/33211769
 # https://github.com/strazzere/anti-emulator/blob/master/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
 # This will go away in a future Android release
-neverallow { all_untrusted_apps -untrusted_app_25 } proc_tty_drivers:file r_file_perms;
+neverallow { all_untrusted_apps -untrusted_app_25 -untrusted_base_app_25 } proc_tty_drivers:file r_file_perms;
 neverallow all_untrusted_apps proc_tty_drivers:file ~r_file_perms;
 
 # Untrusted apps are not allowed to use cgroups.
@@ -256,7 +267,9 @@ neverallow all_untrusted_apps cgroup:file *;
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
 } mnt_sdcard_file:lnk_file *;
 
 # Only privileged apps may find the incident service

--- a/prebuilts/api/30.0/private/app_neverallows.te
+++ b/prebuilts/api/30.0/private/app_neverallows.te
@@ -5,6 +5,7 @@
 define(`all_untrusted_apps',`{
   ephemeral_app
   isolated_app
+  isolated_base_app
   mediaprovider
   mediaprovider_app
   untrusted_app

--- a/prebuilts/api/30.0/private/app_zygote.te
+++ b/prebuilts/api/30.0/private/app_zygote.te
@@ -16,6 +16,7 @@ allow app_zygote self:global_capability_class_set setpcap;
 # Switch SELinux context to isolated app domain.
 allow app_zygote self:process setcurrent;
 allow app_zygote isolated_app:process dyntransition;
+allow app_zygote isolated_base_app:process dyntransition;
 
 # For JIT
 allow app_zygote self:process execmem;
@@ -30,6 +31,7 @@ allow app_zygote system_server:process getpgid;
 
 # Interaction between the app_zygote and its children.
 allow app_zygote isolated_app:process setpgid;
+allow app_zygote isolated_base_app:process setpgid;
 
 # TODO (b/63631799) fix this access
 dontaudit app_zygote mnt_expand_file:dir getattr;
@@ -75,7 +77,7 @@ unix_socket_send(app_zygote, system_unsolzygote, system_server)
 #####
 
 # Only permit transition to isolated_app.
-neverallow app_zygote { domain -isolated_app }:process dyntransition;
+neverallow app_zygote { domain -isolated_app -isolated_base_app }:process dyntransition;
 
 # Only setcon() transitions, no exec() based transitions, except for crash_dump.
 neverallow app_zygote { domain -crash_dump }:process transition;

--- a/prebuilts/api/30.0/private/compat/26.0/26.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/26.0/26.0.ignore.cil
@@ -194,6 +194,7 @@
     untrusted_base_app
     untrusted_base_app_25
     untrusted_base_app_27
+    untrusted_base_app_29
     untrusted_app_all_devpts
     update_engine_log_data_file
     vendor_default_prop

--- a/prebuilts/api/30.0/private/compat/26.0/26.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/26.0/26.0.ignore.cil
@@ -103,6 +103,7 @@
     iorapd_exec
     iorapd_service
     iorapd_tmpfs
+    isolated_base_app
     kmsg_debug_device
     last_boot_reason_prop
     llkd
@@ -190,6 +191,9 @@
     traced_probes_tmpfs
     traced_producer_socket
     traced_tmpfs
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
     untrusted_app_all_devpts
     update_engine_log_data_file
     vendor_default_prop

--- a/prebuilts/api/30.0/private/compat/27.0/27.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/27.0/27.0.ignore.cil
@@ -94,6 +94,7 @@
     iorapd_exec
     iorapd_service
     iorapd_tmpfs
+    isolated_base_app
     last_boot_reason_prop
     llkd
     llkd_exec
@@ -169,6 +170,9 @@
     traceur_app
     traceur_app_tmpfs
     untrusted_app_all_devpts
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
     update_engine_log_data_file
     uri_grants_service
     usbd

--- a/prebuilts/api/30.0/private/compat/27.0/27.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/27.0/27.0.ignore.cil
@@ -173,6 +173,7 @@
     untrusted_base_app
     untrusted_base_app_25
     untrusted_base_app_27
+    untrusted_base_app_29
     update_engine_log_data_file
     uri_grants_service
     usbd

--- a/prebuilts/api/30.0/private/compat/28.0/28.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/28.0/28.0.ignore.cil
@@ -95,6 +95,7 @@
     iorapd_data_file
     iorapd_service
     iorapd_tmpfs
+    isolated_base_app
     mediaswcodec
     mediaswcodec_exec
     mediaswcodec_tmpfs
@@ -145,6 +146,9 @@
     traced_lazy_prop
     uri_grants_service
     use_memfd_prop
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
     vendor_apex_file
     vendor_cgroup_desc_file
     vendor_idc_file

--- a/prebuilts/api/30.0/private/compat/28.0/28.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/28.0/28.0.ignore.cil
@@ -149,6 +149,7 @@
     untrusted_base_app
     untrusted_base_app_25
     untrusted_base_app_27
+    untrusted_base_app_29
     vendor_apex_file
     vendor_cgroup_desc_file
     vendor_idc_file

--- a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
@@ -117,6 +117,7 @@
     untrusted_base_app
     untrusted_base_app_25
     untrusted_base_app_27
+    untrusted_base_app_29
     updater_app
     usb_serial_device
     userspace_reboot_config_prop

--- a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
@@ -72,6 +72,7 @@
     iorap_prefetcherd_data_file
     iorap_prefetcherd_exec
     iorap_prefetcherd_tmpfs
+    isolated_base_app
     mediatranscoding_service
     mediatranscoding
     mediatranscoding_exec
@@ -113,6 +114,9 @@
     traced_perf_socket
     timezonedetector_service
     untrusted_app_29
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
     updater_app
     usb_serial_device
     userspace_reboot_config_prop

--- a/prebuilts/api/30.0/private/isolated_base_app.te
+++ b/prebuilts/api/30.0/private/isolated_base_app.te
@@ -1,0 +1,153 @@
+###
+### Services with isolatedProcess=true in their manifest.
+###
+### This file defines the rules for isolated apps. An "isolated
+### app" is an APP with UID between AID_ISOLATED_START (99000)
+### and AID_ISOLATED_END (99999).
+###
+
+typeattribute isolated_base_app coredomain;
+
+app_domain(isolated_base_app)
+
+# Access already open app data files received over Binder or local socket IPC.
+allow isolated_base_app { app_data_file privapp_data_file }:file { append read write getattr lock map };
+
+allow isolated_base_app activity_service:service_manager find;
+allow isolated_base_app display_service:service_manager find;
+allow isolated_base_app webviewupdate_service:service_manager find;
+
+# Google Breakpad (crash reporter for Chrome) relies on ptrace
+# functionality. Without the ability to ptrace, the crash reporter
+# tool is broken.
+# b/20150694
+# https://code.google.com/p/chromium/issues/detail?id=475270
+allow isolated_base_app self:process ptrace;
+
+# b/32896414: Allow accessing sdcard file descriptors passed to isolated_base_apps
+# by other processes. Open should never be allowed, and is blocked by
+# neverallow rules below.
+# media_rw_data_file is included for sdcardfs, and can be removed if sdcardfs
+# is modified to change the secontext when accessing the lower filesystem.
+allow isolated_base_app { sdcard_type media_rw_data_file }:file { read write append getattr lock map };
+
+# For webviews, isolated_base_app processes can be forked from the webview_zygote
+# in addition to the zygote. Allow access to resources inherited from the
+# webview_zygote process. These rules are specialized copies of the ones in app.te.
+# Inherit FDs from the webview_zygote.
+allow isolated_base_app webview_zygote:fd use;
+# Notify webview_zygote of child death.
+allow isolated_base_app webview_zygote:process sigchld;
+# Inherit logd write socket.
+allow isolated_base_app webview_zygote:unix_dgram_socket write;
+# Read system properties managed by webview_zygote.
+allow isolated_base_app webview_zygote_tmpfs:file read;
+
+# Inherit FDs from the app_zygote.
+allow isolated_base_app app_zygote:fd use;
+# Notify app_zygote of child death.
+allow isolated_base_app app_zygote:process sigchld;
+# Inherit logd write socket.
+allow isolated_base_app app_zygote:unix_dgram_socket write;
+
+# TODO (b/63631799) fix this access
+# suppress denials to /data/local/tmp
+dontaudit isolated_base_app shell_data_file:dir search;
+
+# Write app-specific trace data to the Perfetto traced damon. This requires
+# connecting to its producer socket and obtaining a (per-process) tmpfs fd.
+allow isolated_base_app traced:fd use;
+allow isolated_base_app traced_tmpfs:file { read write getattr map };
+unix_socket_connect(isolated_base_app, traced_producer, traced)
+
+# Allow heap profiling if the main app has been marked as profileable or
+# debuggable.
+can_profile_heap(isolated_base_app)
+
+allow isolated_base_app ashmem_device:chr_file { getattr read ioctl lock map append write };
+
+#####
+##### Neverallow
+#####
+
+# Isolated apps should not directly open app data files themselves.
+neverallow isolated_base_app { app_data_file privapp_data_file }:file open;
+
+# Only allow appending to /data/anr/traces.txt (b/27853304, b/18340553)
+# TODO: are there situations where isolated_base_apps write to this file?
+# TODO: should we tighten these restrictions further?
+neverallow isolated_base_app anr_data_file:file ~{ open append };
+neverallow isolated_base_app anr_data_file:dir ~search;
+
+# Isolated apps must not be permitted to use HwBinder
+neverallow isolated_base_app hwbinder_device:chr_file *;
+neverallow isolated_base_app *:hwservice_manager *;
+
+# Isolated apps must not be permitted to use VndBinder
+neverallow isolated_base_app vndbinder_device:chr_file *;
+
+# Isolated apps must not be permitted to perform actions on Binder and VndBinder service_manager
+# except the find actions for services whitelisted below.
+neverallow isolated_base_app *:service_manager ~find;
+
+# b/17487348
+# Isolated apps can only access three services,
+# activity_service, display_service, webviewupdate_service, and
+# ashmem_device_service.
+neverallow isolated_base_app {
+    service_manager_type
+    -activity_service
+    -ashmem_device_service
+    -display_service
+    -webviewupdate_service
+}:service_manager find;
+
+# Isolated apps shouldn't be able to access the driver directly.
+neverallow isolated_base_app gpu_device:chr_file { rw_file_perms execute };
+
+# Do not allow isolated_base_app access to /cache
+neverallow isolated_base_app cache_file:dir ~{ r_dir_perms };
+neverallow isolated_base_app cache_file:file ~{ read getattr };
+
+# Do not allow isolated_base_app to access external storage, except for files passed
+# via file descriptors (b/32896414).
+neverallow isolated_base_app { storage_file mnt_user_file sdcard_type }:dir ~getattr;
+neverallow isolated_base_app { storage_file mnt_user_file }:file_class_set *;
+neverallow isolated_base_app sdcard_type:{ devfile_class_set lnk_file sock_file fifo_file } *;
+neverallow isolated_base_app sdcard_type:file ~{ read write append getattr lock map };
+
+# Do not allow USB access
+neverallow isolated_base_app { usb_device usbaccessory_device }:chr_file *;
+
+# Restrict the webview_zygote control socket.
+neverallow isolated_base_app webview_zygote:sock_file write;
+
+# Limit the /sys files which isolated_base_app can access. This is important
+# for controlling isolated_base_app attack surface.
+neverallow isolated_base_app {
+  sysfs_type
+  -sysfs_devices_system_cpu
+  -sysfs_transparent_hugepage
+  -sysfs_usb # TODO: check with audio team if needed for isolated_base_app (b/28417852)
+}:file no_rw_file_perms;
+
+# No creation of sockets families other than AF_UNIX sockets.
+# List taken from system/sepolicy/public/global_macros - socket_class_set
+# excluding unix_stream_socket and unix_dgram_socket.
+# Many of these are socket families which have never and will never
+# be compiled into the Android kernel.
+neverallow isolated_base_app self:{
+  socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket
+  key_socket appletalk_socket netlink_route_socket
+  netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket
+  netlink_selinux_socket netlink_audit_socket netlink_dnrt_socket
+  netlink_kobject_uevent_socket tun_socket netlink_iscsi_socket
+  netlink_fib_lookup_socket netlink_connector_socket netlink_netfilter_socket
+  netlink_generic_socket netlink_scsitransport_socket netlink_rdma_socket
+  netlink_crypto_socket sctp_socket icmp_socket ax25_socket ipx_socket
+  netrom_socket atmpvc_socket x25_socket rose_socket decnet_socket atmsvc_socket
+  rds_socket irda_socket pppox_socket llc_socket can_socket tipc_socket
+  bluetooth_socket iucv_socket rxrpc_socket isdn_socket phonet_socket
+  ieee802154_socket caif_socket alg_socket nfc_socket vsock_socket kcm_socket
+  qipcrtr_socket smc_socket xdp_socket
+} create;

--- a/prebuilts/api/30.0/private/mac_permissions.xml
+++ b/prebuilts/api/30.0/private/mac_permissions.xml
@@ -56,6 +56,16 @@
       <seinfo value="media" />
     </signer>
 
+    <!-- Shared dev key in AOSP -->
+    <signer signature="@SHARED" >
+      <seinfo value="base" />
+    </signer>
+
+    <!-- Release dev key in AOSP -->
+    <signer signature="@RELEASE" >
+      <seinfo value="base" />
+    </signer>
+
     <signer signature="@NETWORK_STACK" >
       <seinfo value="network_stack" />
     </signer>

--- a/prebuilts/api/30.0/private/seapp_contexts
+++ b/prebuilts/api/30.0/private/seapp_contexts
@@ -125,8 +125,8 @@ neverallow user=((?!shared_relro).)* domain=shared_relro
 
 # neverallow non-isolated uids into isolated_app domain
 # and vice versa
-neverallow user=_isolated domain=((?!isolated_app).)*
-neverallow user=((?!_isolated).)* domain=isolated_app
+neverallow user=_isolated domain=((?!isolated_(base_)?app).)*
+neverallow user=((?!_isolated).)* domain=isolated_base_app
 
 # uid shell should always be in shell domain, however non-shell
 # uid's can be in shell domain
@@ -151,6 +151,7 @@ user=radio seinfo=platform domain=radio type=radio_data_file
 user=shared_relro domain=shared_relro
 user=shell seinfo=platform domain=shell name=com.android.shell type=shell_data_file
 user=webview_zygote seinfo=webview_zygote domain=webview_zygote
+user=_isolated seinfo=base domain=isolated_base_app levelFrom=user
 user=_isolated domain=isolated_app levelFrom=user
 user=_app seinfo=app_zygote domain=app_zygote levelFrom=user
 user=_app seinfo=media domain=mediaprovider name=android.process.media type=app_data_file levelFrom=user

--- a/prebuilts/api/30.0/private/seapp_contexts
+++ b/prebuilts/api/30.0/private/seapp_contexts
@@ -169,9 +169,14 @@ user=_app isPrivApp=true name=com.android.vzwomatrigger domain=vzwomatrigger_app
 #user=_app isPrivApp=true name=com.google.android.gsf domain=gmscore_app type=privapp_data_file levelFrom=user
 user=_app isPrivApp=true name=app.seamlessupdate.client domain=updater_app type=app_data_file levelFrom=user
 user=_app minTargetSdkVersion=30 domain=untrusted_app type=app_data_file levelFrom=all
+user=_app seinfo=base minTargetSdkVersion=30 domain=untrusted_base_app type=app_data_file levelFrom=all
 user=_app minTargetSdkVersion=29 domain=untrusted_app_29 type=app_data_file levelFrom=all
+user=_app seinfo=base minTargetSdkVersion=29 domain=untrusted_base_app_29 type=app_data_file levelFrom=all
 user=_app minTargetSdkVersion=28 domain=untrusted_app_27 type=app_data_file levelFrom=all
+user=_app seinfo=base minTargetSdkVersion=28 domain=untrusted_base_app_27 type=app_data_file levelFrom=all
 user=_app minTargetSdkVersion=26 domain=untrusted_app_27 type=app_data_file levelFrom=user
+user=_app seinfo=base minTargetSdkVersion=26 domain=untrusted_base_app_27 type=app_data_file levelFrom=user
 user=_app domain=untrusted_app_25 type=app_data_file levelFrom=user
+user=_app seinfo=base domain=untrusted_base_app_25 type=app_data_file levelFrom=user
 user=_app minTargetSdkVersion=28 fromRunAs=true domain=runas_app levelFrom=all
 user=_app fromRunAs=true domain=runas_app levelFrom=user

--- a/prebuilts/api/30.0/private/technical_debt.cil
+++ b/prebuilts/api/30.0/private/technical_debt.cil
@@ -7,18 +7,18 @@
 
 ; Apps, except isolated apps, are clients of Allocator HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_allocator_client;
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_allocator_client;
 ;     typeattribute hal_allocator_client halclientdomain;
-(typeattributeset hal_allocator_client ((and (appdomain) ((not (isolated_app))))))
+(typeattributeset hal_allocator_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 (typeattributeset halclientdomain (hal_allocator_client))
 
 ; Apps, except isolated apps, are clients of OMX-related services
 ; Unfortunately, we can't currently express this in module policy language:
-(typeattributeset hal_omx_client ((and (appdomain) ((not (isolated_app))))))
+(typeattributeset hal_omx_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Codec2-related services
 ; Unfortunately, we can't currently express this in module policy language:
-(typeattributeset hal_codec2_client ((and (appdomain) ((not (isolated_app))))))
+(typeattributeset hal_codec2_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Drm-related services
 ; Unfortunately, we can't currently express this in module policy language:
@@ -26,18 +26,18 @@
 
 ; Apps, except isolated apps, are clients of Configstore HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_configstore_client;
-(typeattributeset hal_configstore_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_configstore_client;
+(typeattributeset hal_configstore_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Graphics Allocator HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_graphics_allocator_client;
-(typeattributeset hal_graphics_allocator_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_graphics_allocator_client;
+(typeattributeset hal_graphics_allocator_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Cas HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_cas_client;
-(typeattributeset hal_cas_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_cas_client;
+(typeattributeset hal_cas_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Domains hosting Camera HAL implementations are clients of Allocator HAL
 ; Unfortunately, we can't currently express this in module policy language:
@@ -46,8 +46,8 @@
 
 ; Apps, except isolated apps, are clients of Neuralnetworks HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_neuralnetworks_client;
-(typeattributeset hal_neuralnetworks_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_neuralnetworks_client;
+(typeattributeset hal_neuralnetworks_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; TODO(b/112056006): move these to mapping files when/if we implement 'versioned' attributes.
 ; Rename untrusted_app_visible_* to untrusted_app_visible_*_violators.
@@ -61,5 +61,5 @@
 
 ; Apps, except isolated apps, are clients of BufferHub HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_cas_client;
-(typeattributeset hal_bufferhub_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_cas_client;
+(typeattributeset hal_bufferhub_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))

--- a/prebuilts/api/30.0/private/untrusted_base_app.te
+++ b/prebuilts/api/30.0/private/untrusted_base_app.te
@@ -1,0 +1,25 @@
+###
+### Untrusted apps.
+###
+### This file defines the rules for untrusted apps.
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+typeattribute untrusted_base_app coredomain;
+
+app_domain(untrusted_base_app)
+untrusted_app_domain(untrusted_base_app)
+net_domain(untrusted_base_app)
+bluetooth_domain(untrusted_base_app)

--- a/prebuilts/api/30.0/private/untrusted_base_app_25.te
+++ b/prebuilts/api/30.0/private/untrusted_base_app_25.te
@@ -1,0 +1,63 @@
+###
+### untrusted_base_app_25
+###
+### This file defines the rules for untrusted apps running with
+### targetSdkVersion <= 25.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+typeattribute untrusted_base_app_25 coredomain;
+
+app_domain(untrusted_base_app_25)
+untrusted_app_domain(untrusted_base_app_25)
+net_domain(untrusted_base_app_25)
+bluetooth_domain(untrusted_base_app_25)
+
+# b/34115651, b/33308258 - net.dns* properties read
+# This will go away in a future Android release
+get_prop(untrusted_base_app_25, net_dns_prop)
+auditallow untrusted_base_app_25 net_dns_prop:file read;
+
+# b/35917228 - /proc/misc access
+# This will go away in a future Android release
+allow untrusted_base_app_25 proc_misc:file r_file_perms;
+
+# Access to /proc/tty/drivers, to allow apps to determine if they
+# are running in an emulated environment.
+# b/33214085 b/33814662 b/33791054 b/33211769
+# https://github.com/strazzere/anti-emulator/blob/master/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
+# This will go away in a future Android release
+allow untrusted_base_app_25 proc_tty_drivers:file r_file_perms;
+
+# Text relocation support for API < 23. This is now disallowed for targetSdkVersion>=Q.
+# https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#text-relocations-enforced-for-api-level-23
+# allow untrusted_base_app_25 { apk_data_file app_data_file asec_public_file }:file execmod;
+
+# The ability to call exec() on files in the apps home directories
+# for targetApi<=25. This is also allowed for targetAPIs 26, 27,
+# and 28 in untrusted_app_27.te.
+# allow untrusted_base_app_25 app_data_file:file execute_no_trans;
+# auditallow untrusted_base_app_25 app_data_file:file { execute execute_no_trans };
+
+# The ability to invoke dex2oat. Historically required by ART, now only
+# allowed for targetApi<=28 for compat reasons.
+allow untrusted_base_app_25 dex2oat_exec:file rx_file_perms;
+userdebug_or_eng(`auditallow untrusted_base_app_25 dex2oat_exec:file rx_file_perms;')
+
+# The ability to talk to /dev/ashmem directly. targetApi>=29 must use
+# ASharedMemory instead.
+allow untrusted_base_app_25 ashmem_device:chr_file rw_file_perms;
+auditallow untrusted_base_app_25 ashmem_device:chr_file open;

--- a/prebuilts/api/30.0/private/untrusted_base_app_27.te
+++ b/prebuilts/api/30.0/private/untrusted_base_app_27.te
@@ -1,0 +1,47 @@
+###
+### Untrusted_27.
+###
+### This file defines the rules for untrusted apps running with
+### 25 < targetSdkVersion <= 28.
+###
+### This file defines the rules for untrusted apps.
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_base_app_27 domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+typeattribute untrusted_base_app_27 coredomain;
+
+app_domain(untrusted_base_app_27)
+untrusted_app_domain(untrusted_base_app_27)
+net_domain(untrusted_base_app_27)
+bluetooth_domain(untrusted_base_app_27)
+
+# Text relocation support for API < 23. This is now disallowed for targetSdkVersion>=Q.
+# https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#text-relocations-enforced-for-api-level-23
+# allow untrusted_base_app_27 { apk_data_file app_data_file asec_public_file }:file execmod;
+
+# The ability to call exec() on files in the apps home directories
+# for targetApi 26, 27, and 28.
+# allow untrusted_base_app_27 app_data_file:file execute_no_trans;
+# auditallow untrusted_base_app_27 app_data_file:file { execute execute_no_trans };
+
+# The ability to invoke dex2oat. Historically required by ART, now only
+# allowed for targetApi<=28 for compat reasons.
+allow untrusted_base_app_27 dex2oat_exec:file rx_file_perms;
+userdebug_or_eng(`auditallow untrusted_base_app_27 dex2oat_exec:file rx_file_perms;')
+
+# The ability to talk to /dev/ashmem directly. targetApi>=29 must use
+# ASharedMemory instead.
+allow untrusted_base_app_27 ashmem_device:chr_file rw_file_perms;
+auditallow untrusted_base_app_27 ashmem_device:chr_file open;

--- a/prebuilts/api/30.0/private/untrusted_base_app_29.te
+++ b/prebuilts/api/30.0/private/untrusted_base_app_29.te
@@ -1,0 +1,16 @@
+###
+### Untrusted_29.
+###
+### This file defines the rules for untrusted apps running with
+### targetSdkVersion = 29.
+###
+### See public/untrusted_app.te for more information about which apps are
+### placed in this selinux domain.
+###
+
+typeattribute untrusted_app_29 coredomain;
+
+app_domain(untrusted_app_29)
+untrusted_app_domain(untrusted_app_29)
+net_domain(untrusted_app_29)
+bluetooth_domain(untrusted_app_29)

--- a/prebuilts/api/30.0/private/webview_zygote.te
+++ b/prebuilts/api/30.0/private/webview_zygote.te
@@ -26,6 +26,7 @@ allow webview_zygote self:global_capability_class_set setpcap;
 # Switch SELinux context to app domains.
 allow webview_zygote self:process setcurrent;
 allow webview_zygote isolated_app:process dyntransition;
+allow webview_zygote isolated_base_app:process dyntransition;
 
 # For art.
 allow webview_zygote dalvikcache_data_file:dir r_dir_perms;
@@ -45,6 +46,7 @@ allow webview_zygote system_server:process getpgid;
 
 # Interaction between the webview_zygote and its children.
 allow webview_zygote isolated_app:process setpgid;
+allow webview_zygote isolated_base_app:process setpgid;
 
 # TODO (b/63631799) fix this access
 # Suppress denials to storage. Webview zygote should not be accessing.
@@ -85,7 +87,7 @@ unix_socket_send(webview_zygote, system_unsolzygote, system_server)
 #####
 
 # Only permit transition to isolated_app.
-neverallow webview_zygote { domain -isolated_app }:process dyntransition;
+neverallow webview_zygote { domain -isolated_app -isolated_base_app }:process dyntransition;
 
 # Only setcon() transitions, no exec() based transitions, except for crash_dump.
 neverallow webview_zygote { domain -crash_dump }:process transition;

--- a/prebuilts/api/30.0/public/app.te
+++ b/prebuilts/api/30.0/public/app.te
@@ -28,8 +28,8 @@ allow appdomain dalvikcache_data_file:dir { search getattr };
 allow appdomain dalvikcache_data_file:file r_file_perms;
 
 # Read the /sdcard and /mnt/sdcard symlinks
-allow { appdomain -isolated_app } rootfs:lnk_file r_file_perms;
-allow { appdomain -isolated_app } tmpfs:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } rootfs:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } tmpfs:lnk_file r_file_perms;
 
 # Search /storage/emulated tmpfs mount.
 allow appdomain tmpfs:dir r_dir_perms;
@@ -66,8 +66,8 @@ allow appdomain appdomain:fifo_file rw_file_perms;
 allow appdomain surfaceflinger:unix_stream_socket { read write setopt getattr getopt shutdown };
 
 # App sandbox file accesses.
-allow { appdomain -isolated_app } { app_data_file privapp_data_file }:dir create_dir_perms;
-allow { appdomain -isolated_app } { app_data_file privapp_data_file }:file create_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } { app_data_file privapp_data_file }:dir create_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app } { app_data_file privapp_data_file }:file create_file_perms;
 
 # Traverse into expanded storage
 allow appdomain mnt_expand_file:dir r_dir_perms;
@@ -78,7 +78,7 @@ allow appdomain misc_user_data_file:dir r_dir_perms;
 allow appdomain misc_user_data_file:file r_file_perms;
 
 # TextClassifier
-r_dir_file({ appdomain -isolated_app }, textclassifier_data_file)
+r_dir_file({ appdomain -isolated_app -isolated_base_app }, textclassifier_data_file)
 
 # Access to OEM provided data and apps
 allow appdomain oemfs:dir r_dir_perms;
@@ -101,7 +101,7 @@ not_full_treble(`
 
 full_treble_only(`
     # For looking up Renderscript vendor drivers
-    allow { appdomain -isolated_app } vendor_file:dir { open read };
+    allow { appdomain -isolated_app -isolated_base_app } vendor_file:dir { open read };
 ')
 
 # Allow apps access to /vendor/app except for privileged
@@ -186,6 +186,7 @@ r_dir_file({
   appdomain
   -ephemeral_app
   -isolated_app
+  -isolated_base_app
   -platform_app
   -priv_app
   -shell
@@ -198,6 +199,7 @@ userdebug_or_eng(`
     appdomain
     -ephemeral_app
     -isolated_app
+    -isolated_base_app
     -platform_app
     -priv_app
     -shell
@@ -209,7 +211,7 @@ userdebug_or_eng(`
 
 # Grant GPU access to all processes started by Zygote.
 # They need that to render the standard UI.
-allow { appdomain -isolated_app } gpu_device:chr_file rw_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } gpu_device:chr_file rw_file_perms;
 
 # Use the Binder.
 binder_use(appdomain)
@@ -239,33 +241,33 @@ allow appdomain system_data_file:lnk_file r_file_perms;
 allow appdomain system_data_file:file { getattr read map };
 
 # Allow read/stat of /data/media files passed by Binder or local socket IPC.
-allow { appdomain -isolated_app } media_rw_data_file:file { read getattr };
+allow { appdomain -isolated_app -isolated_base_app } media_rw_data_file:file { read getattr };
 
 # Read and write /data/data/com.android.providers.telephony files passed over Binder.
-allow { appdomain -isolated_app } radio_data_file:file { read write getattr };
+allow { appdomain -isolated_app -isolated_base_app } radio_data_file:file { read write getattr };
 
 # Allow access to external storage; we have several visible mount points under /storage
 # and symlinks to primary storage at places like /storage/sdcard0 and /mnt/user/0/primary
-allow { appdomain -isolated_app -ephemeral_app } storage_file:dir r_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } storage_file:lnk_file r_file_perms;
-allow { appdomain -isolated_app -ephemeral_app } mnt_user_file:dir r_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } mnt_user_file:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } storage_file:dir r_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } storage_file:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } mnt_user_file:dir r_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } mnt_user_file:lnk_file r_file_perms;
 
 # Read/write visible storage
-allow { appdomain -isolated_app -ephemeral_app } sdcard_type:dir create_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } sdcard_type:file create_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } sdcard_type:dir create_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } sdcard_type:file create_file_perms;
 # This should be removed if sdcardfs is modified to alter the secontext for its
 # accesses to the underlying FS.
-allow { appdomain -isolated_app -ephemeral_app } media_rw_data_file:dir create_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } media_rw_data_file:file create_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } media_rw_data_file:dir create_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } media_rw_data_file:file create_file_perms;
 
 # Allow apps to use the USB Accessory interface.
 # http://developer.android.com/guide/topics/connectivity/usb/accessory.html
 #
 # USB devices are first opened by the system server (USBDeviceManagerService)
 # and the file descriptor is passed to the right Activity via binder.
-allow { appdomain -isolated_app -ephemeral_app } usb_device:chr_file { read write getattr ioctl };
-allow { appdomain -isolated_app -ephemeral_app } usbaccessory_device:chr_file { read write getattr };
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } usb_device:chr_file { read write getattr ioctl };
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } usbaccessory_device:chr_file { read write getattr };
 
 # For art.
 allow appdomain dalvikcache_data_file:file execute;
@@ -289,9 +291,9 @@ control_logd({ appdomain -ephemeral_app })
 # application inherit logd write socket (urge is to deprecate this long term)
 allow appdomain zygote:unix_dgram_socket write;
 
-allow { appdomain -isolated_app -ephemeral_app } keystore:keystore_key { get_state get insert delete exist list sign verify };
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } keystore:keystore_key { get_state get insert delete exist list sign verify };
 
-use_keystore({ appdomain -isolated_app -ephemeral_app })
+use_keystore({ appdomain -isolated_app -isolated_base_app -ephemeral_app })
 
 use_credstore({ appdomain -isolated_app -ephemeral_app })
 
@@ -301,16 +303,16 @@ allow appdomain console_device:chr_file { read write };
 allowxperm { appdomain -bluetooth } self:{ rawip_socket tcp_socket udp_socket }
   ioctl { unpriv_sock_ioctls unpriv_tty_ioctls };
 
-allow { appdomain -isolated_app } ion_device:chr_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } ion_device:chr_file r_file_perms;
 
 # Allow AAudio apps to use shared memory file descriptors from the HAL
-allow { appdomain -isolated_app } hal_audio:fd use;
+allow { appdomain -isolated_app -isolated_base_app } hal_audio:fd use;
 
 # Allow app to access shared memory created by camera HAL1
-allow { appdomain -isolated_app } hal_camera:fd use;
+allow { appdomain -isolated_app -isolated_base_app } hal_camera:fd use;
 
 # RenderScript always-passthrough HAL
-allow { appdomain -isolated_app } hal_renderscript_hwservice:hwservice_manager find;
+allow { appdomain -isolated_app -isolated_base_app } hal_renderscript_hwservice:hwservice_manager find;
 allow appdomain same_process_hal_file:file { execute read open getattr map };
 
 # TODO: switch to meminfo service
@@ -319,12 +321,12 @@ allow appdomain proc_meminfo:file r_file_perms;
 # For app fuse.
 allow appdomain app_fuse_file:file { getattr read append write map };
 
-pdx_client({ appdomain -isolated_app -ephemeral_app }, display_client)
-pdx_client({ appdomain -isolated_app -ephemeral_app }, display_manager)
-pdx_client({ appdomain -isolated_app -ephemeral_app }, display_vsync)
-pdx_client({ appdomain -isolated_app -ephemeral_app }, performance_client)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, display_client)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, display_manager)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, display_vsync)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, performance_client)
 # Apps do not directly open the IPC socket for bufferhubd.
-pdx_use({ appdomain -isolated_app -ephemeral_app }, bufferhub_client)
+pdx_use({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, bufferhub_client)
 
 ###
 ### CTS-specific rules
@@ -337,8 +339,8 @@ allow appdomain runas_exec:file getattr;
 
 # Apps receive an open tun fd from the framework for
 # device traffic. Do not allow untrusted app to directly open tun_device
-allow { appdomain -isolated_app -ephemeral_app } tun_device:chr_file { read write getattr append ioctl };
-allowxperm { appdomain -isolated_app -ephemeral_app } tun_device:chr_file ioctl TUNGETIFF;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } tun_device:chr_file { read write getattr append ioctl };
+allowxperm { appdomain -isolated_app -isolated_base_app -ephemeral_app } tun_device:chr_file ioctl TUNGETIFF;
 
 # Connect to adbd and use a socket transferred from it.
 # This is used for e.g. adb backup/restore.
@@ -383,7 +385,7 @@ neverallow appdomain {
 }:chr_file { read write };
 
 # Note: Try expanding list of app domains in the future.
-neverallow { untrusted_app isolated_app shell } graphics_device:chr_file { read write };
+neverallow { untrusted_app isolated_app isolated_base_app shell } graphics_device:chr_file { read write };
 
 neverallow { appdomain -nfc } nfc_device:chr_file
     { read write };
@@ -541,6 +543,7 @@ neverallow appdomain {
 neverallow {
   bluetooth
   isolated_app
+  isolated_base_app
   nfc
   radio
   shared_relro

--- a/prebuilts/api/30.0/public/domain.te
+++ b/prebuilts/api/30.0/public/domain.te
@@ -84,7 +84,7 @@ allow { domain -hwservicemanager -vndservicemanager } binder_device:chr_file rw_
 allow domain binderfs:dir { getattr search };
 allow domain binderfs_logs_proc:dir search;
 
-allow { domain -servicemanager -vndservicemanager -isolated_app } hwbinder_device:chr_file rw_file_perms;
+allow { domain -servicemanager -vndservicemanager -isolated_app -isolated_base_app } hwbinder_device:chr_file rw_file_perms;
 allow domain ptmx_device:chr_file rw_file_perms;
 allow domain random_device:chr_file rw_file_perms;
 allow domain proc_random:dir r_dir_perms;
@@ -1170,6 +1170,7 @@ neverallow {
 } system_app_data_file:dir_file_class_set { create unlink open };
 neverallow {
   isolated_app
+  isolated_base_app
   untrusted_app_all # finer-grained rules for appdomain are listed below
   ephemeral_app
   priv_app

--- a/prebuilts/api/30.0/public/hal_camera.te
+++ b/prebuilts/api/30.0/public/hal_camera.te
@@ -13,7 +13,7 @@ allow hal_camera ion_device:chr_file rw_file_perms;
 allow { hal_camera_client hal_camera_server } hal_graphics_allocator:fd use;
 
 # Allow hal_camera to use fd from app,gralloc,and ashmem HAL
-allow hal_camera { appdomain -isolated_app }:fd use;
+allow hal_camera { appdomain -isolated_app -isolated_base_app }:fd use;
 allow hal_camera surfaceflinger:fd use;
 allow hal_camera hal_allocator_server:fd use;
 

--- a/prebuilts/api/30.0/public/hal_sensors.te
+++ b/prebuilts/api/30.0/public/hal_sensors.te
@@ -4,7 +4,7 @@ binder_call(hal_sensors_client, hal_sensors_server)
 hal_attribute_hwservice(hal_sensors, hal_sensors_hwservice)
 
 # Allow sensor hals to access ashmem memory allocated by apps
-allow hal_sensors { appdomain -isolated_app }:fd use;
+allow hal_sensors { appdomain -isolated_app -isolated_base_app }:fd use;
 
 # Allow sensor hals to access ashmem memory allocated by android.hidl.allocator
 # fd is passed in from framework sensorservice HAL.

--- a/prebuilts/api/30.0/public/isolated_base_app.te
+++ b/prebuilts/api/30.0/public/isolated_base_app.te
@@ -1,0 +1,9 @@
+###
+### Services with isolatedProcess=true in their manifest.
+###
+### This file defines the rules for isolated apps. An "isolated
+### app" is an APP with UID between AID_ISOLATED_START (99000)
+### and AID_ISOLATED_END (99999).
+###
+
+type isolated_base_app, domain;

--- a/prebuilts/api/30.0/public/untrusted_base_app.te
+++ b/prebuilts/api/30.0/public/untrusted_base_app.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app, domain;

--- a/prebuilts/api/30.0/public/untrusted_base_app_25.te
+++ b/prebuilts/api/30.0/public/untrusted_base_app_25.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app_25, domain;

--- a/prebuilts/api/30.0/public/untrusted_base_app_27.te
+++ b/prebuilts/api/30.0/public/untrusted_base_app_27.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app_27, domain;

--- a/prebuilts/api/30.0/public/untrusted_base_app_29.te
+++ b/prebuilts/api/30.0/public/untrusted_base_app_29.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app_29, domain;

--- a/private/app_neverallows.te
+++ b/private/app_neverallows.te
@@ -13,6 +13,10 @@ define(`all_untrusted_apps',`{
   untrusted_app_27
   untrusted_app_29
   untrusted_app_all
+  untrusted_base_app
+  untrusted_base_app_25
+  untrusted_base_app_27
+  untrusted_base_app_29
 }')
 # Receive or send uevent messages.
 neverallow all_untrusted_apps domain:netlink_kobject_uevent_socket *;
@@ -56,7 +60,9 @@ neverallow all_untrusted_apps app_exec_data_file:file
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
   -runas_app
 } { app_data_file privapp_data_file }:file execute_no_trans;
 
@@ -66,7 +72,9 @@ neverallow {
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
 } dex2oat_exec:file no_x_file_perms;
 
 # Do not allow untrusted apps to be assigned mlstrustedsubject.
@@ -118,8 +126,11 @@ neverallow all_untrusted_apps *:{
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
   -untrusted_app_29
+  -untrusted_base_app_29
 } domain:netlink_route_socket { bind nlmsg_readpriv };
 
 # Do not allow untrusted apps access to /cache
@@ -245,7 +256,7 @@ neverallow all_untrusted_apps selinuxfs:file no_rw_file_perms;
 # b/33214085 b/33814662 b/33791054 b/33211769
 # https://github.com/strazzere/anti-emulator/blob/master/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
 # This will go away in a future Android release
-neverallow { all_untrusted_apps -untrusted_app_25 } proc_tty_drivers:file r_file_perms;
+neverallow { all_untrusted_apps -untrusted_app_25 -untrusted_base_app_25 } proc_tty_drivers:file r_file_perms;
 neverallow all_untrusted_apps proc_tty_drivers:file ~r_file_perms;
 
 # Untrusted apps are not allowed to use cgroups.
@@ -256,7 +267,9 @@ neverallow all_untrusted_apps cgroup:file *;
 neverallow {
   all_untrusted_apps
   -untrusted_app_25
+  -untrusted_base_app_25
   -untrusted_app_27
+  -untrusted_base_app_27
 } mnt_sdcard_file:lnk_file *;
 
 # Only privileged apps may find the incident service

--- a/private/app_neverallows.te
+++ b/private/app_neverallows.te
@@ -5,6 +5,7 @@
 define(`all_untrusted_apps',`{
   ephemeral_app
   isolated_app
+  isolated_base_app
   mediaprovider
   mediaprovider_app
   untrusted_app

--- a/private/app_zygote.te
+++ b/private/app_zygote.te
@@ -16,6 +16,7 @@ allow app_zygote self:global_capability_class_set setpcap;
 # Switch SELinux context to isolated app domain.
 allow app_zygote self:process setcurrent;
 allow app_zygote isolated_app:process dyntransition;
+allow app_zygote isolated_base_app:process dyntransition;
 
 # For JIT
 allow app_zygote self:process execmem;
@@ -30,6 +31,7 @@ allow app_zygote system_server:process getpgid;
 
 # Interaction between the app_zygote and its children.
 allow app_zygote isolated_app:process setpgid;
+allow app_zygote isolated_base_app:process setpgid;
 
 # TODO (b/63631799) fix this access
 dontaudit app_zygote mnt_expand_file:dir getattr;
@@ -75,7 +77,7 @@ unix_socket_send(app_zygote, system_unsolzygote, system_server)
 #####
 
 # Only permit transition to isolated_app.
-neverallow app_zygote { domain -isolated_app }:process dyntransition;
+neverallow app_zygote { domain -isolated_app -isolated_base_app }:process dyntransition;
 
 # Only setcon() transitions, no exec() based transitions, except for crash_dump.
 neverallow app_zygote { domain -crash_dump }:process transition;

--- a/private/compat/26.0/26.0.ignore.cil
+++ b/private/compat/26.0/26.0.ignore.cil
@@ -191,6 +191,10 @@
     traced_probes_tmpfs
     traced_producer_socket
     traced_tmpfs
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
+    untrusted_base_app_29
     untrusted_app_all_devpts
     update_engine_log_data_file
     vendor_default_prop

--- a/private/compat/26.0/26.0.ignore.cil
+++ b/private/compat/26.0/26.0.ignore.cil
@@ -103,6 +103,7 @@
     iorapd_exec
     iorapd_service
     iorapd_tmpfs
+    isolated_base_app
     kmsg_debug_device
     last_boot_reason_prop
     llkd

--- a/private/compat/27.0/27.0.ignore.cil
+++ b/private/compat/27.0/27.0.ignore.cil
@@ -170,6 +170,10 @@
     traceur_app
     traceur_app_tmpfs
     untrusted_app_all_devpts
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
+    untrusted_base_app_29
     update_engine_log_data_file
     uri_grants_service
     usbd

--- a/private/compat/27.0/27.0.ignore.cil
+++ b/private/compat/27.0/27.0.ignore.cil
@@ -94,6 +94,7 @@
     iorapd_exec
     iorapd_service
     iorapd_tmpfs
+    isolated_base_app
     last_boot_reason_prop
     llkd
     llkd_exec

--- a/private/compat/28.0/28.0.ignore.cil
+++ b/private/compat/28.0/28.0.ignore.cil
@@ -95,6 +95,7 @@
     iorapd_data_file
     iorapd_service
     iorapd_tmpfs
+    isolated_base_app
     mediaswcodec
     mediaswcodec_exec
     mediaswcodec_tmpfs

--- a/private/compat/28.0/28.0.ignore.cil
+++ b/private/compat/28.0/28.0.ignore.cil
@@ -146,6 +146,10 @@
     traced_lazy_prop
     uri_grants_service
     use_memfd_prop
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
+    untrusted_base_app_29
     vendor_apex_file
     vendor_cgroup_desc_file
     vendor_idc_file

--- a/private/compat/29.0/29.0.ignore.cil
+++ b/private/compat/29.0/29.0.ignore.cil
@@ -114,6 +114,10 @@
     traced_perf_socket
     timezonedetector_service
     untrusted_app_29
+    untrusted_base_app
+    untrusted_base_app_25
+    untrusted_base_app_27
+    untrusted_base_app_29
     updater_app
     usb_serial_device
     userspace_reboot_config_prop

--- a/private/compat/29.0/29.0.ignore.cil
+++ b/private/compat/29.0/29.0.ignore.cil
@@ -72,6 +72,7 @@
     iorap_prefetcherd_data_file
     iorap_prefetcherd_exec
     iorap_prefetcherd_tmpfs
+    isolated_base_app
     mediatranscoding_service
     mediatranscoding
     mediatranscoding_exec

--- a/private/isolated_base_app.te
+++ b/private/isolated_base_app.te
@@ -1,0 +1,153 @@
+###
+### Services with isolatedProcess=true in their manifest.
+###
+### This file defines the rules for isolated apps. An "isolated
+### app" is an APP with UID between AID_ISOLATED_START (99000)
+### and AID_ISOLATED_END (99999).
+###
+
+typeattribute isolated_base_app coredomain;
+
+app_domain(isolated_base_app)
+
+# Access already open app data files received over Binder or local socket IPC.
+allow isolated_base_app { app_data_file privapp_data_file }:file { append read write getattr lock map };
+
+allow isolated_base_app activity_service:service_manager find;
+allow isolated_base_app display_service:service_manager find;
+allow isolated_base_app webviewupdate_service:service_manager find;
+
+# Google Breakpad (crash reporter for Chrome) relies on ptrace
+# functionality. Without the ability to ptrace, the crash reporter
+# tool is broken.
+# b/20150694
+# https://code.google.com/p/chromium/issues/detail?id=475270
+allow isolated_base_app self:process ptrace;
+
+# b/32896414: Allow accessing sdcard file descriptors passed to isolated_base_apps
+# by other processes. Open should never be allowed, and is blocked by
+# neverallow rules below.
+# media_rw_data_file is included for sdcardfs, and can be removed if sdcardfs
+# is modified to change the secontext when accessing the lower filesystem.
+allow isolated_base_app { sdcard_type media_rw_data_file }:file { read write append getattr lock map };
+
+# For webviews, isolated_base_app processes can be forked from the webview_zygote
+# in addition to the zygote. Allow access to resources inherited from the
+# webview_zygote process. These rules are specialized copies of the ones in app.te.
+# Inherit FDs from the webview_zygote.
+allow isolated_base_app webview_zygote:fd use;
+# Notify webview_zygote of child death.
+allow isolated_base_app webview_zygote:process sigchld;
+# Inherit logd write socket.
+allow isolated_base_app webview_zygote:unix_dgram_socket write;
+# Read system properties managed by webview_zygote.
+allow isolated_base_app webview_zygote_tmpfs:file read;
+
+# Inherit FDs from the app_zygote.
+allow isolated_base_app app_zygote:fd use;
+# Notify app_zygote of child death.
+allow isolated_base_app app_zygote:process sigchld;
+# Inherit logd write socket.
+allow isolated_base_app app_zygote:unix_dgram_socket write;
+
+# TODO (b/63631799) fix this access
+# suppress denials to /data/local/tmp
+dontaudit isolated_base_app shell_data_file:dir search;
+
+# Write app-specific trace data to the Perfetto traced damon. This requires
+# connecting to its producer socket and obtaining a (per-process) tmpfs fd.
+allow isolated_base_app traced:fd use;
+allow isolated_base_app traced_tmpfs:file { read write getattr map };
+unix_socket_connect(isolated_base_app, traced_producer, traced)
+
+# Allow heap profiling if the main app has been marked as profileable or
+# debuggable.
+can_profile_heap(isolated_base_app)
+
+allow isolated_base_app ashmem_device:chr_file { getattr read ioctl lock map append write };
+
+#####
+##### Neverallow
+#####
+
+# Isolated apps should not directly open app data files themselves.
+neverallow isolated_base_app { app_data_file privapp_data_file }:file open;
+
+# Only allow appending to /data/anr/traces.txt (b/27853304, b/18340553)
+# TODO: are there situations where isolated_base_apps write to this file?
+# TODO: should we tighten these restrictions further?
+neverallow isolated_base_app anr_data_file:file ~{ open append };
+neverallow isolated_base_app anr_data_file:dir ~search;
+
+# Isolated apps must not be permitted to use HwBinder
+neverallow isolated_base_app hwbinder_device:chr_file *;
+neverallow isolated_base_app *:hwservice_manager *;
+
+# Isolated apps must not be permitted to use VndBinder
+neverallow isolated_base_app vndbinder_device:chr_file *;
+
+# Isolated apps must not be permitted to perform actions on Binder and VndBinder service_manager
+# except the find actions for services whitelisted below.
+neverallow isolated_base_app *:service_manager ~find;
+
+# b/17487348
+# Isolated apps can only access three services,
+# activity_service, display_service, webviewupdate_service, and
+# ashmem_device_service.
+neverallow isolated_base_app {
+    service_manager_type
+    -activity_service
+    -ashmem_device_service
+    -display_service
+    -webviewupdate_service
+}:service_manager find;
+
+# Isolated apps shouldn't be able to access the driver directly.
+neverallow isolated_base_app gpu_device:chr_file { rw_file_perms execute };
+
+# Do not allow isolated_base_app access to /cache
+neverallow isolated_base_app cache_file:dir ~{ r_dir_perms };
+neverallow isolated_base_app cache_file:file ~{ read getattr };
+
+# Do not allow isolated_base_app to access external storage, except for files passed
+# via file descriptors (b/32896414).
+neverallow isolated_base_app { storage_file mnt_user_file sdcard_type }:dir ~getattr;
+neverallow isolated_base_app { storage_file mnt_user_file }:file_class_set *;
+neverallow isolated_base_app sdcard_type:{ devfile_class_set lnk_file sock_file fifo_file } *;
+neverallow isolated_base_app sdcard_type:file ~{ read write append getattr lock map };
+
+# Do not allow USB access
+neverallow isolated_base_app { usb_device usbaccessory_device }:chr_file *;
+
+# Restrict the webview_zygote control socket.
+neverallow isolated_base_app webview_zygote:sock_file write;
+
+# Limit the /sys files which isolated_base_app can access. This is important
+# for controlling isolated_base_app attack surface.
+neverallow isolated_base_app {
+  sysfs_type
+  -sysfs_devices_system_cpu
+  -sysfs_transparent_hugepage
+  -sysfs_usb # TODO: check with audio team if needed for isolated_base_app (b/28417852)
+}:file no_rw_file_perms;
+
+# No creation of sockets families other than AF_UNIX sockets.
+# List taken from system/sepolicy/public/global_macros - socket_class_set
+# excluding unix_stream_socket and unix_dgram_socket.
+# Many of these are socket families which have never and will never
+# be compiled into the Android kernel.
+neverallow isolated_base_app self:{
+  socket tcp_socket udp_socket rawip_socket netlink_socket packet_socket
+  key_socket appletalk_socket netlink_route_socket
+  netlink_tcpdiag_socket netlink_nflog_socket netlink_xfrm_socket
+  netlink_selinux_socket netlink_audit_socket netlink_dnrt_socket
+  netlink_kobject_uevent_socket tun_socket netlink_iscsi_socket
+  netlink_fib_lookup_socket netlink_connector_socket netlink_netfilter_socket
+  netlink_generic_socket netlink_scsitransport_socket netlink_rdma_socket
+  netlink_crypto_socket sctp_socket icmp_socket ax25_socket ipx_socket
+  netrom_socket atmpvc_socket x25_socket rose_socket decnet_socket atmsvc_socket
+  rds_socket irda_socket pppox_socket llc_socket can_socket tipc_socket
+  bluetooth_socket iucv_socket rxrpc_socket isdn_socket phonet_socket
+  ieee802154_socket caif_socket alg_socket nfc_socket vsock_socket kcm_socket
+  qipcrtr_socket smc_socket xdp_socket
+} create;

--- a/private/mac_permissions.xml
+++ b/private/mac_permissions.xml
@@ -56,6 +56,16 @@
       <seinfo value="media" />
     </signer>
 
+    <!-- Shared dev key in AOSP -->
+    <signer signature="@SHARED" >
+      <seinfo value="base" />
+    </signer>
+
+    <!-- Release dev key in AOSP -->
+    <signer signature="@RELEASE" >
+      <seinfo value="base" />
+    </signer>
+
     <signer signature="@NETWORK_STACK" >
       <seinfo value="network_stack" />
     </signer>

--- a/private/seapp_contexts
+++ b/private/seapp_contexts
@@ -125,8 +125,8 @@ neverallow user=((?!shared_relro).)* domain=shared_relro
 
 # neverallow non-isolated uids into isolated_app domain
 # and vice versa
-neverallow user=_isolated domain=((?!isolated_app).)*
-neverallow user=((?!_isolated).)* domain=isolated_app
+neverallow user=_isolated domain=((?!isolated_(base_)?app).)*
+neverallow user=((?!_isolated).)* domain=isolated_base_app
 
 # uid shell should always be in shell domain, however non-shell
 # uid's can be in shell domain
@@ -151,6 +151,7 @@ user=radio seinfo=platform domain=radio type=radio_data_file
 user=shared_relro domain=shared_relro
 user=shell seinfo=platform domain=shell name=com.android.shell type=shell_data_file
 user=webview_zygote seinfo=webview_zygote domain=webview_zygote
+user=_isolated seinfo=base domain=isolated_base_app levelFrom=user
 user=_isolated domain=isolated_app levelFrom=user
 user=_app seinfo=app_zygote domain=app_zygote levelFrom=user
 user=_app seinfo=media domain=mediaprovider name=android.process.media type=app_data_file levelFrom=user

--- a/private/seapp_contexts
+++ b/private/seapp_contexts
@@ -169,9 +169,14 @@ user=_app isPrivApp=true name=com.android.vzwomatrigger domain=vzwomatrigger_app
 #user=_app isPrivApp=true name=com.google.android.gsf domain=gmscore_app type=privapp_data_file levelFrom=user
 user=_app isPrivApp=true name=app.seamlessupdate.client domain=updater_app type=app_data_file levelFrom=user
 user=_app minTargetSdkVersion=30 domain=untrusted_app type=app_data_file levelFrom=all
+user=_app seinfo=base minTargetSdkVersion=30 domain=untrusted_base_app type=app_data_file levelFrom=all
 user=_app minTargetSdkVersion=29 domain=untrusted_app_29 type=app_data_file levelFrom=all
+user=_app seinfo=base minTargetSdkVersion=29 domain=untrusted_base_app_29 type=app_data_file levelFrom=all
 user=_app minTargetSdkVersion=28 domain=untrusted_app_27 type=app_data_file levelFrom=all
+user=_app seinfo=base minTargetSdkVersion=28 domain=untrusted_base_app_27 type=app_data_file levelFrom=all
 user=_app minTargetSdkVersion=26 domain=untrusted_app_27 type=app_data_file levelFrom=user
+user=_app seinfo=base minTargetSdkVersion=26 domain=untrusted_base_app_27 type=app_data_file levelFrom=user
 user=_app domain=untrusted_app_25 type=app_data_file levelFrom=user
+user=_app seinfo=base domain=untrusted_base_app_25 type=app_data_file levelFrom=user
 user=_app minTargetSdkVersion=28 fromRunAs=true domain=runas_app levelFrom=all
 user=_app fromRunAs=true domain=runas_app levelFrom=user

--- a/private/technical_debt.cil
+++ b/private/technical_debt.cil
@@ -7,18 +7,18 @@
 
 ; Apps, except isolated apps, are clients of Allocator HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_allocator_client;
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_allocator_client;
 ;     typeattribute hal_allocator_client halclientdomain;
-(typeattributeset hal_allocator_client ((and (appdomain) ((not (isolated_app))))))
+(typeattributeset hal_allocator_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 (typeattributeset halclientdomain (hal_allocator_client))
 
 ; Apps, except isolated apps, are clients of OMX-related services
 ; Unfortunately, we can't currently express this in module policy language:
-(typeattributeset hal_omx_client ((and (appdomain) ((not (isolated_app))))))
+(typeattributeset hal_omx_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Codec2-related services
 ; Unfortunately, we can't currently express this in module policy language:
-(typeattributeset hal_codec2_client ((and (appdomain) ((not (isolated_app))))))
+(typeattributeset hal_codec2_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Drm-related services
 ; Unfortunately, we can't currently express this in module policy language:
@@ -26,18 +26,18 @@
 
 ; Apps, except isolated apps, are clients of Configstore HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_configstore_client;
-(typeattributeset hal_configstore_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_configstore_client;
+(typeattributeset hal_configstore_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Graphics Allocator HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_graphics_allocator_client;
-(typeattributeset hal_graphics_allocator_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_graphics_allocator_client;
+(typeattributeset hal_graphics_allocator_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Apps, except isolated apps, are clients of Cas HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_cas_client;
-(typeattributeset hal_cas_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_cas_client;
+(typeattributeset hal_cas_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; Domains hosting Camera HAL implementations are clients of Allocator HAL
 ; Unfortunately, we can't currently express this in module policy language:
@@ -46,8 +46,8 @@
 
 ; Apps, except isolated apps, are clients of Neuralnetworks HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_neuralnetworks_client;
-(typeattributeset hal_neuralnetworks_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_neuralnetworks_client;
+(typeattributeset hal_neuralnetworks_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))
 
 ; TODO(b/112056006): move these to mapping files when/if we implement 'versioned' attributes.
 ; Rename untrusted_app_visible_* to untrusted_app_visible_*_violators.
@@ -61,5 +61,5 @@
 
 ; Apps, except isolated apps, are clients of BufferHub HAL
 ; Unfortunately, we can't currently express this in module policy language:
-;     typeattribute { appdomain -isolated_app } hal_cas_client;
-(typeattributeset hal_bufferhub_client ((and (appdomain) ((not (isolated_app))))))
+;     typeattribute { appdomain -isolated_app -isolated_base_app } hal_cas_client;
+(typeattributeset hal_bufferhub_client ((and (appdomain) ((not (or (isolated_app) (isolated_base_app)))))))

--- a/private/untrusted_base_app.te
+++ b/private/untrusted_base_app.te
@@ -1,0 +1,25 @@
+###
+### Untrusted apps.
+###
+### This file defines the rules for untrusted apps.
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+typeattribute untrusted_base_app coredomain;
+
+app_domain(untrusted_base_app)
+untrusted_app_domain(untrusted_base_app)
+net_domain(untrusted_base_app)
+bluetooth_domain(untrusted_base_app)

--- a/private/untrusted_base_app_25.te
+++ b/private/untrusted_base_app_25.te
@@ -1,0 +1,63 @@
+###
+### untrusted_base_app_25
+###
+### This file defines the rules for untrusted apps running with
+### targetSdkVersion <= 25.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+typeattribute untrusted_base_app_25 coredomain;
+
+app_domain(untrusted_base_app_25)
+untrusted_app_domain(untrusted_base_app_25)
+net_domain(untrusted_base_app_25)
+bluetooth_domain(untrusted_base_app_25)
+
+# b/34115651, b/33308258 - net.dns* properties read
+# This will go away in a future Android release
+get_prop(untrusted_base_app_25, net_dns_prop)
+auditallow untrusted_base_app_25 net_dns_prop:file read;
+
+# b/35917228 - /proc/misc access
+# This will go away in a future Android release
+allow untrusted_base_app_25 proc_misc:file r_file_perms;
+
+# Access to /proc/tty/drivers, to allow apps to determine if they
+# are running in an emulated environment.
+# b/33214085 b/33814662 b/33791054 b/33211769
+# https://github.com/strazzere/anti-emulator/blob/master/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
+# This will go away in a future Android release
+allow untrusted_base_app_25 proc_tty_drivers:file r_file_perms;
+
+# Text relocation support for API < 23. This is now disallowed for targetSdkVersion>=Q.
+# https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#text-relocations-enforced-for-api-level-23
+# allow untrusted_base_app_25 { apk_data_file app_data_file asec_public_file }:file execmod;
+
+# The ability to call exec() on files in the apps home directories
+# for targetApi<=25. This is also allowed for targetAPIs 26, 27,
+# and 28 in untrusted_app_27.te.
+# allow untrusted_base_app_25 app_data_file:file execute_no_trans;
+# auditallow untrusted_base_app_25 app_data_file:file { execute execute_no_trans };
+
+# The ability to invoke dex2oat. Historically required by ART, now only
+# allowed for targetApi<=28 for compat reasons.
+allow untrusted_base_app_25 dex2oat_exec:file rx_file_perms;
+userdebug_or_eng(`auditallow untrusted_base_app_25 dex2oat_exec:file rx_file_perms;')
+
+# The ability to talk to /dev/ashmem directly. targetApi>=29 must use
+# ASharedMemory instead.
+allow untrusted_base_app_25 ashmem_device:chr_file rw_file_perms;
+auditallow untrusted_base_app_25 ashmem_device:chr_file open;

--- a/private/untrusted_base_app_27.te
+++ b/private/untrusted_base_app_27.te
@@ -1,0 +1,47 @@
+###
+### Untrusted_27.
+###
+### This file defines the rules for untrusted apps running with
+### 25 < targetSdkVersion <= 28.
+###
+### This file defines the rules for untrusted apps.
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_base_app_27 domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+typeattribute untrusted_base_app_27 coredomain;
+
+app_domain(untrusted_base_app_27)
+untrusted_app_domain(untrusted_base_app_27)
+net_domain(untrusted_base_app_27)
+bluetooth_domain(untrusted_base_app_27)
+
+# Text relocation support for API < 23. This is now disallowed for targetSdkVersion>=Q.
+# https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#text-relocations-enforced-for-api-level-23
+# allow untrusted_base_app_27 { apk_data_file app_data_file asec_public_file }:file execmod;
+
+# The ability to call exec() on files in the apps home directories
+# for targetApi 26, 27, and 28.
+# allow untrusted_base_app_27 app_data_file:file execute_no_trans;
+# auditallow untrusted_base_app_27 app_data_file:file { execute execute_no_trans };
+
+# The ability to invoke dex2oat. Historically required by ART, now only
+# allowed for targetApi<=28 for compat reasons.
+allow untrusted_base_app_27 dex2oat_exec:file rx_file_perms;
+userdebug_or_eng(`auditallow untrusted_base_app_27 dex2oat_exec:file rx_file_perms;')
+
+# The ability to talk to /dev/ashmem directly. targetApi>=29 must use
+# ASharedMemory instead.
+allow untrusted_base_app_27 ashmem_device:chr_file rw_file_perms;
+auditallow untrusted_base_app_27 ashmem_device:chr_file open;

--- a/private/untrusted_base_app_29.te
+++ b/private/untrusted_base_app_29.te
@@ -1,0 +1,16 @@
+###
+### Untrusted_29.
+###
+### This file defines the rules for untrusted apps running with
+### targetSdkVersion = 29.
+###
+### See public/untrusted_app.te for more information about which apps are
+### placed in this selinux domain.
+###
+
+typeattribute untrusted_base_app_29 coredomain;
+
+app_domain(untrusted_base_app_29)
+untrusted_app_domain(untrusted_base_app_29)
+net_domain(untrusted_base_app_29)
+bluetooth_domain(untrusted_base_app_29)

--- a/private/webview_zygote.te
+++ b/private/webview_zygote.te
@@ -26,6 +26,7 @@ allow webview_zygote self:global_capability_class_set setpcap;
 # Switch SELinux context to app domains.
 allow webview_zygote self:process setcurrent;
 allow webview_zygote isolated_app:process dyntransition;
+allow webview_zygote isolated_base_app:process dyntransition;
 
 # For art.
 allow webview_zygote dalvikcache_data_file:dir r_dir_perms;
@@ -45,6 +46,7 @@ allow webview_zygote system_server:process getpgid;
 
 # Interaction between the webview_zygote and its children.
 allow webview_zygote isolated_app:process setpgid;
+allow webview_zygote isolated_base_app:process setpgid;
 
 # TODO (b/63631799) fix this access
 # Suppress denials to storage. Webview zygote should not be accessing.
@@ -85,7 +87,7 @@ unix_socket_send(webview_zygote, system_unsolzygote, system_server)
 #####
 
 # Only permit transition to isolated_app.
-neverallow webview_zygote { domain -isolated_app }:process dyntransition;
+neverallow webview_zygote { domain -isolated_app -isolated_base_app }:process dyntransition;
 
 # Only setcon() transitions, no exec() based transitions, except for crash_dump.
 neverallow webview_zygote { domain -crash_dump }:process transition;

--- a/public/app.te
+++ b/public/app.te
@@ -28,8 +28,8 @@ allow appdomain dalvikcache_data_file:dir { search getattr };
 allow appdomain dalvikcache_data_file:file r_file_perms;
 
 # Read the /sdcard and /mnt/sdcard symlinks
-allow { appdomain -isolated_app } rootfs:lnk_file r_file_perms;
-allow { appdomain -isolated_app } tmpfs:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } rootfs:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } tmpfs:lnk_file r_file_perms;
 
 # Search /storage/emulated tmpfs mount.
 allow appdomain tmpfs:dir r_dir_perms;
@@ -66,8 +66,8 @@ allow appdomain appdomain:fifo_file rw_file_perms;
 allow appdomain surfaceflinger:unix_stream_socket { read write setopt getattr getopt shutdown };
 
 # App sandbox file accesses.
-allow { appdomain -isolated_app } { app_data_file privapp_data_file }:dir create_dir_perms;
-allow { appdomain -isolated_app } { app_data_file privapp_data_file }:file create_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } { app_data_file privapp_data_file }:dir create_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app } { app_data_file privapp_data_file }:file create_file_perms;
 
 # Traverse into expanded storage
 allow appdomain mnt_expand_file:dir r_dir_perms;
@@ -78,7 +78,7 @@ allow appdomain misc_user_data_file:dir r_dir_perms;
 allow appdomain misc_user_data_file:file r_file_perms;
 
 # TextClassifier
-r_dir_file({ appdomain -isolated_app }, textclassifier_data_file)
+r_dir_file({ appdomain -isolated_app -isolated_base_app }, textclassifier_data_file)
 
 # Access to OEM provided data and apps
 allow appdomain oemfs:dir r_dir_perms;
@@ -101,7 +101,7 @@ not_full_treble(`
 
 full_treble_only(`
     # For looking up Renderscript vendor drivers
-    allow { appdomain -isolated_app } vendor_file:dir { open read };
+    allow { appdomain -isolated_app -isolated_base_app } vendor_file:dir { open read };
 ')
 
 # Allow apps access to /vendor/app except for privileged
@@ -186,6 +186,7 @@ r_dir_file({
   appdomain
   -ephemeral_app
   -isolated_app
+  -isolated_base_app
   -platform_app
   -priv_app
   -shell
@@ -198,6 +199,7 @@ userdebug_or_eng(`
     appdomain
     -ephemeral_app
     -isolated_app
+    -isolated_base_app
     -platform_app
     -priv_app
     -shell
@@ -209,7 +211,7 @@ userdebug_or_eng(`
 
 # Grant GPU access to all processes started by Zygote.
 # They need that to render the standard UI.
-allow { appdomain -isolated_app } gpu_device:chr_file rw_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } gpu_device:chr_file rw_file_perms;
 
 # Use the Binder.
 binder_use(appdomain)
@@ -239,33 +241,33 @@ allow appdomain system_data_file:lnk_file r_file_perms;
 allow appdomain system_data_file:file { getattr read map };
 
 # Allow read/stat of /data/media files passed by Binder or local socket IPC.
-allow { appdomain -isolated_app } media_rw_data_file:file { read getattr };
+allow { appdomain -isolated_app -isolated_base_app } media_rw_data_file:file { read getattr };
 
 # Read and write /data/data/com.android.providers.telephony files passed over Binder.
-allow { appdomain -isolated_app } radio_data_file:file { read write getattr };
+allow { appdomain -isolated_app -isolated_base_app } radio_data_file:file { read write getattr };
 
 # Allow access to external storage; we have several visible mount points under /storage
 # and symlinks to primary storage at places like /storage/sdcard0 and /mnt/user/0/primary
-allow { appdomain -isolated_app -ephemeral_app } storage_file:dir r_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } storage_file:lnk_file r_file_perms;
-allow { appdomain -isolated_app -ephemeral_app } mnt_user_file:dir r_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } mnt_user_file:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } storage_file:dir r_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } storage_file:lnk_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } mnt_user_file:dir r_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } mnt_user_file:lnk_file r_file_perms;
 
 # Read/write visible storage
-allow { appdomain -isolated_app -ephemeral_app } sdcard_type:dir create_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } sdcard_type:file create_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } sdcard_type:dir create_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } sdcard_type:file create_file_perms;
 # This should be removed if sdcardfs is modified to alter the secontext for its
 # accesses to the underlying FS.
-allow { appdomain -isolated_app -ephemeral_app } media_rw_data_file:dir create_dir_perms;
-allow { appdomain -isolated_app -ephemeral_app } media_rw_data_file:file create_file_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } media_rw_data_file:dir create_dir_perms;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } media_rw_data_file:file create_file_perms;
 
 # Allow apps to use the USB Accessory interface.
 # http://developer.android.com/guide/topics/connectivity/usb/accessory.html
 #
 # USB devices are first opened by the system server (USBDeviceManagerService)
 # and the file descriptor is passed to the right Activity via binder.
-allow { appdomain -isolated_app -ephemeral_app } usb_device:chr_file { read write getattr ioctl };
-allow { appdomain -isolated_app -ephemeral_app } usbaccessory_device:chr_file { read write getattr };
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } usb_device:chr_file { read write getattr ioctl };
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } usbaccessory_device:chr_file { read write getattr };
 
 # For art.
 allow appdomain dalvikcache_data_file:file execute;
@@ -289,9 +291,9 @@ control_logd({ appdomain -ephemeral_app })
 # application inherit logd write socket (urge is to deprecate this long term)
 allow appdomain zygote:unix_dgram_socket write;
 
-allow { appdomain -isolated_app -ephemeral_app } keystore:keystore_key { get_state get insert delete exist list sign verify };
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } keystore:keystore_key { get_state get insert delete exist list sign verify };
 
-use_keystore({ appdomain -isolated_app -ephemeral_app })
+use_keystore({ appdomain -isolated_app -isolated_base_app -ephemeral_app })
 
 use_credstore({ appdomain -isolated_app -ephemeral_app })
 
@@ -301,16 +303,16 @@ allow appdomain console_device:chr_file { read write };
 allowxperm { appdomain -bluetooth } self:{ rawip_socket tcp_socket udp_socket }
   ioctl { unpriv_sock_ioctls unpriv_tty_ioctls };
 
-allow { appdomain -isolated_app } ion_device:chr_file r_file_perms;
+allow { appdomain -isolated_app -isolated_base_app } ion_device:chr_file r_file_perms;
 
 # Allow AAudio apps to use shared memory file descriptors from the HAL
-allow { appdomain -isolated_app } hal_audio:fd use;
+allow { appdomain -isolated_app -isolated_base_app } hal_audio:fd use;
 
 # Allow app to access shared memory created by camera HAL1
-allow { appdomain -isolated_app } hal_camera:fd use;
+allow { appdomain -isolated_app -isolated_base_app } hal_camera:fd use;
 
 # RenderScript always-passthrough HAL
-allow { appdomain -isolated_app } hal_renderscript_hwservice:hwservice_manager find;
+allow { appdomain -isolated_app -isolated_base_app } hal_renderscript_hwservice:hwservice_manager find;
 allow appdomain same_process_hal_file:file { execute read open getattr map };
 
 # TODO: switch to meminfo service
@@ -319,12 +321,12 @@ allow appdomain proc_meminfo:file r_file_perms;
 # For app fuse.
 allow appdomain app_fuse_file:file { getattr read append write map };
 
-pdx_client({ appdomain -isolated_app -ephemeral_app }, display_client)
-pdx_client({ appdomain -isolated_app -ephemeral_app }, display_manager)
-pdx_client({ appdomain -isolated_app -ephemeral_app }, display_vsync)
-pdx_client({ appdomain -isolated_app -ephemeral_app }, performance_client)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, display_client)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, display_manager)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, display_vsync)
+pdx_client({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, performance_client)
 # Apps do not directly open the IPC socket for bufferhubd.
-pdx_use({ appdomain -isolated_app -ephemeral_app }, bufferhub_client)
+pdx_use({ appdomain -isolated_app -isolated_base_app -ephemeral_app }, bufferhub_client)
 
 ###
 ### CTS-specific rules
@@ -337,8 +339,8 @@ allow appdomain runas_exec:file getattr;
 
 # Apps receive an open tun fd from the framework for
 # device traffic. Do not allow untrusted app to directly open tun_device
-allow { appdomain -isolated_app -ephemeral_app } tun_device:chr_file { read write getattr append ioctl };
-allowxperm { appdomain -isolated_app -ephemeral_app } tun_device:chr_file ioctl TUNGETIFF;
+allow { appdomain -isolated_app -isolated_base_app -ephemeral_app } tun_device:chr_file { read write getattr append ioctl };
+allowxperm { appdomain -isolated_app -isolated_base_app -ephemeral_app } tun_device:chr_file ioctl TUNGETIFF;
 
 # Connect to adbd and use a socket transferred from it.
 # This is used for e.g. adb backup/restore.
@@ -383,7 +385,7 @@ neverallow appdomain {
 }:chr_file { read write };
 
 # Note: Try expanding list of app domains in the future.
-neverallow { untrusted_app isolated_app shell } graphics_device:chr_file { read write };
+neverallow { untrusted_app isolated_app isolated_base_app shell } graphics_device:chr_file { read write };
 
 neverallow { appdomain -nfc } nfc_device:chr_file
     { read write };
@@ -541,6 +543,7 @@ neverallow appdomain {
 neverallow {
   bluetooth
   isolated_app
+  isolated_base_app
   nfc
   radio
   shared_relro

--- a/public/domain.te
+++ b/public/domain.te
@@ -84,7 +84,7 @@ allow { domain -hwservicemanager -vndservicemanager } binder_device:chr_file rw_
 allow domain binderfs:dir { getattr search };
 allow domain binderfs_logs_proc:dir search;
 
-allow { domain -servicemanager -vndservicemanager -isolated_app } hwbinder_device:chr_file rw_file_perms;
+allow { domain -servicemanager -vndservicemanager -isolated_app -isolated_base_app } hwbinder_device:chr_file rw_file_perms;
 allow domain ptmx_device:chr_file rw_file_perms;
 allow domain random_device:chr_file rw_file_perms;
 allow domain proc_random:dir r_dir_perms;
@@ -1170,6 +1170,7 @@ neverallow {
 } system_app_data_file:dir_file_class_set { create unlink open };
 neverallow {
   isolated_app
+  isolated_base_app
   untrusted_app_all # finer-grained rules for appdomain are listed below
   ephemeral_app
   priv_app

--- a/public/hal_camera.te
+++ b/public/hal_camera.te
@@ -13,7 +13,7 @@ allow hal_camera ion_device:chr_file rw_file_perms;
 allow { hal_camera_client hal_camera_server } hal_graphics_allocator:fd use;
 
 # Allow hal_camera to use fd from app,gralloc,and ashmem HAL
-allow hal_camera { appdomain -isolated_app }:fd use;
+allow hal_camera { appdomain -isolated_app -isolated_base_app }:fd use;
 allow hal_camera surfaceflinger:fd use;
 allow hal_camera hal_allocator_server:fd use;
 

--- a/public/hal_sensors.te
+++ b/public/hal_sensors.te
@@ -4,7 +4,7 @@ binder_call(hal_sensors_client, hal_sensors_server)
 hal_attribute_hwservice(hal_sensors, hal_sensors_hwservice)
 
 # Allow sensor hals to access ashmem memory allocated by apps
-allow hal_sensors { appdomain -isolated_app }:fd use;
+allow hal_sensors { appdomain -isolated_app -isolated_base_app }:fd use;
 
 # Allow sensor hals to access ashmem memory allocated by android.hidl.allocator
 # fd is passed in from framework sensorservice HAL.

--- a/public/isolated_base_app.te
+++ b/public/isolated_base_app.te
@@ -1,0 +1,9 @@
+###
+### Services with isolatedProcess=true in their manifest.
+###
+### This file defines the rules for isolated apps. An "isolated
+### app" is an APP with UID between AID_ISOLATED_START (99000)
+### and AID_ISOLATED_END (99999).
+###
+
+type isolated_base_app, domain;

--- a/public/untrusted_base_app.te
+++ b/public/untrusted_base_app.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app, domain;

--- a/public/untrusted_base_app_25.te
+++ b/public/untrusted_base_app_25.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app_25, domain;

--- a/public/untrusted_base_app_27.te
+++ b/public/untrusted_base_app_27.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app_27, domain;

--- a/public/untrusted_base_app_29.te
+++ b/public/untrusted_base_app_29.te
@@ -1,0 +1,19 @@
+###
+### Untrusted apps.
+###
+### Apps are labeled based on mac_permissions.xml (maps signer and
+### optionally package name to seinfo value) and seapp_contexts (maps UID
+### and optionally seinfo value to domain for process and type for data
+### directory).  The untrusted_app domain is the default assignment in
+### seapp_contexts for any app with UID between APP_AID (10000)
+### and AID_ISOLATED_START (99000) if the app has no specific seinfo
+### value as determined from mac_permissions.xml.  In current AOSP, this
+### domain is assigned to all non-system apps as well as to any system apps
+### that are not signed by the platform key.  To move
+### a system app into a specific domain, add a signer entry for it to
+### mac_permissions.xml and assign it one of the pre-existing seinfo values
+### or define and use a new seinfo value in both mac_permissions.xml and
+### seapp_contexts.
+###
+
+type untrusted_base_app_29, domain;

--- a/tests/treble_sepolicy_tests.py
+++ b/tests/treble_sepolicy_tests.py
@@ -28,7 +28,9 @@ coreAppdomain = {
         'shell',
         'system_app',
         'untrusted_app',
+        'untrusted_base_app',
         'untrusted_app_25',
+        'untrusted_base_app_25'
         }
 coredomainWhitelist = {
         'adbd',


### PR DESCRIPTION
Based on 3b942f7b6bc95931dc5e67f9d7b14887c29a9cc9 in 10. See https://github.com/GrapheneOS/os_issue_tracker/issues/273