### PR TITLE
add isolated_base_app type to compatibility mapping

### DIFF
--- a/private/compat/29.0/29.0.ignore.cil
+++ b/private/compat/29.0/29.0.ignore.cil
@@ -72,6 +72,7 @@
     iorap_prefetcherd_data_file
     iorap_prefetcherd_exec
     iorap_prefetcherd_tmpfs
+    isolated_base_app
     mediatranscoding_service
     mediatranscoding
     mediatranscoding_exec


### PR DESCRIPTION
Fixes the build

```
FAILED: out/target/product/sargo/obj/FAKE/treble_sepolicy_tests_29.0_intermediates/treble_sepolicy_tests_29.0
/bin/bash -c "(out/host/linux-x86/bin/treble_sepolicy_tests -l          out/host/linux-x86/lib64/libsepolwrap.so  -f out/target/product/sargo/system/etc/selinux/p
lat_file_contexts  -f out/target/product/sargo/vendor/etc/selinux/vendor_file_contexts  -f out/target/product/sargo/product/etc/selinux/product_file_contexts           -
b out/target/product/sargo/obj/ETC/built_plat_sepolicy_intermediates/built_plat_sepolicy -m out/target/product/sargo/obj/FAKE/treble_sepolicy_tests_29.0_intermedi
ates/29.0_mapping.combined.cil          -o out/target/product/sargo/obj/FAKE/treble_sepolicy_tests_29.0_intermediates/built_29.0_plat_sepolicy -p out/target/produ
ct/sargo/obj/ETC/sepolicy_intermediates/sepolicy                -u out/target/product/sargo/obj/ETC/built_plat_sepolicy_intermediates/base_plat_pub_policy.cil ) &
& (touch out/target/product/sargo/obj/FAKE/treble_sepolicy_tests_29.0_intermediates/treble_sepolicy_tests_29.0 )"
SELinux: The following public types were found added to the policy without an entry into the compatibility mapping file(s) found in private/compat/V.v/V.v[.ignore
].cil, where V.v is the latest API level.
isolated_base_app

See examples of how to fix this:
https://android-review.googlesource.com/c/platform/system/sepolicy/+/781036
https://android-review.googlesource.com/c/platform/system/sepolicy/+/852612

03:30:06 ninja failed with: exit status 1
```