### PR TITLE
allow radio domain to find mediametrics_service

### DIFF
--- a/prebuilts/api/34.0/private/radio.te
+++ b/prebuilts/api/34.0/private/radio.te
@@ -17,6 +17,8 @@ set_prop(radio, ctl_rildaemon_prop)
 # Telephony code contains time / time zone detection logic so it reads the associated properties.
 get_prop(radio, time_prop)
 
+allow radio mediametrics_service:service_manager find;
+
 # allow telephony to access platform compat to log permission denials
 allow radio platform_compat_service:service_manager find;
 

--- a/private/radio.te
+++ b/private/radio.te
@@ -17,6 +17,8 @@ set_prop(radio, ctl_rildaemon_prop)
 # Telephony code contains time / time zone detection logic so it reads the associated properties.
 get_prop(radio, time_prop)
 
+allow radio mediametrics_service:service_manager find;
+
 # allow telephony to access platform compat to log permission denials
 allow radio platform_compat_service:service_manager find;
 


### PR DESCRIPTION
It's indirectly used by the EmergencyDialer activity (packages/services/Telephony/src/com/android/phone/EmergencyDialer.java).

Lack of this permission led to EmergencyDialer stalling at startup for 5 seconds while it was trying
to connect to the mediametrics_service.

Stock Pixel OS doesn't need this, since the SafetyHub priv_app is used as an emergency dialer there.