### PR TITLE
allow system_server to get and set deny_new_usb2_prop

### DIFF
--- a/private/system_server.te
+++ b/private/system_server.te
@@ -885,6 +885,7 @@ get_prop(system_server, traced_oome_heap_session_count_prop)
 get_prop(system_server, sensors_config_prop)
 
 get_prop(system_server, security_usb_mode_prop)
+set_prop(system_server, deny_new_usb2_prop)
 
 # Create a socket for connections from debuggerd.
 allow system_server system_ndebug_socket:sock_file create_file_perms;


### PR DESCRIPTION
Dynamic handling of deny_new_usb2 has been moved to system_server.