### PR TITLE
add ro.build.version.sdk_full to build_prop ctx

### DIFF
--- a/private/property_contexts
+++ b/private/property_contexts
@@ -1109,6 +1109,7 @@ ro.build.version.preview_sdk_fingerprint  u:object_r:build_prop:s0 exact string
 ro.build.version.release                  u:object_r:build_prop:s0 exact string
 ro.build.version.release_or_codename      u:object_r:build_prop:s0 exact string
 ro.build.version.sdk                      u:object_r:build_prop:s0 exact int
+ro.build.version.sdk_full		  u:object_r:build_prop:s0 exact string
 ro.build.version.security_patch           u:object_r:build_prop:s0 exact string
 
 ro.actionable_compatible_property.enabled u:object_r:build_prop:s0 exact bool


### PR DESCRIPTION
https://github.com/GrapheneOS/device_google_gs101-sepolicy/pull/14
https://github.com/GrapheneOS/device_google_gs201-sepolicy/pull/13
https://github.com/GrapheneOS/device_google_zuma-sepolicy/pull/10
https://github.com/GrapheneOS/device_google_zumapro-sepolicy/pull/7