### PR TITLE
net: Forbid RTM_GETADDR

### DIFF
--- a/prebuilts/api/202404/private/net.te
+++ b/prebuilts/api/202404/private/net.te
@@ -17,3 +17,11 @@ allow {
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv nlmsg_getneigh };
 
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
+

--- a/prebuilts/api/202404/public/net.te
+++ b/prebuilts/api/202404/public/net.te
@@ -14,7 +14,7 @@ allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms
 # Connect to ports.
 allow netdomain port_type:tcp_socket name_connect;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown  };
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/prebuilts/api/202504/private/net.te
+++ b/prebuilts/api/202504/private/net.te
@@ -17,6 +17,14 @@ allow {
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv nlmsg_getneigh };
 
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
+
 ###
 ### Domain with network access
 ###

--- a/prebuilts/api/29.0/public/net.te
+++ b/prebuilts/api/29.0/public/net.te
@@ -18,7 +18,7 @@ allow {netdomain -ephemeral_app} node_type:{ icmp_socket rawip_socket tcp_socket
 allow {netdomain -ephemeral_app} port_type:udp_socket name_bind;
 allow {netdomain -ephemeral_app} port_type:tcp_socket name_bind;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append bind connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append bind connect getopt setopt shutdown  };
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/prebuilts/api/30.0/public/net.te
+++ b/prebuilts/api/30.0/public/net.te
@@ -18,7 +18,7 @@ allow {netdomain -ephemeral_app} node_type:{ icmp_socket rawip_socket tcp_socket
 allow {netdomain -ephemeral_app} port_type:udp_socket name_bind;
 allow {netdomain -ephemeral_app} port_type:tcp_socket name_bind;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown  };
 # b/141455849 gate RTM_GETLINK with a new permission nlmsg_readpriv and block access from
 # untrusted_apps. Some untrusted apps (e.g. untrusted_app_25-29) are granted access elsewhere
 # to avoid app-compat breakage.
@@ -28,6 +28,14 @@ allow {
   -mediaprovider
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv };
+
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/prebuilts/api/31.0/public/net.te
+++ b/prebuilts/api/31.0/public/net.te
@@ -18,7 +18,7 @@ allow {netdomain -ephemeral_app} node_type:{ icmp_socket rawip_socket tcp_socket
 allow {netdomain -ephemeral_app} port_type:udp_socket name_bind;
 allow {netdomain -ephemeral_app} port_type:tcp_socket name_bind;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown  };
 # b/141455849 gate RTM_GETLINK with a new permission nlmsg_readpriv and block access from
 # untrusted_apps. Some untrusted apps (e.g. untrusted_app_25-29) are granted access elsewhere
 # to avoid app-compat breakage.
@@ -28,6 +28,14 @@ allow {
   -mediaprovider
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv };
+
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/prebuilts/api/32.0/public/net.te
+++ b/prebuilts/api/32.0/public/net.te
@@ -18,7 +18,7 @@ allow {netdomain -ephemeral_app} node_type:{ icmp_socket rawip_socket tcp_socket
 allow {netdomain -ephemeral_app} port_type:udp_socket name_bind;
 allow {netdomain -ephemeral_app} port_type:tcp_socket name_bind;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown  };
 # b/141455849 gate RTM_GETLINK with a new permission nlmsg_readpriv and block access from
 # untrusted_apps. Some untrusted apps (e.g. untrusted_app_25-29) are granted access elsewhere
 # to avoid app-compat breakage.
@@ -28,6 +28,14 @@ allow {
   -mediaprovider
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv };
+
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/prebuilts/api/33.0/private/net.te
+++ b/prebuilts/api/33.0/private/net.te
@@ -16,3 +16,10 @@ allow {
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv nlmsg_getneigh };
 
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;

--- a/prebuilts/api/33.0/public/net.te
+++ b/prebuilts/api/33.0/public/net.te
@@ -14,7 +14,7 @@ allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms
 # Connect to ports.
 allow netdomain port_type:tcp_socket name_connect;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown  };
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/prebuilts/api/34.0/private/net.te
+++ b/prebuilts/api/34.0/private/net.te
@@ -17,3 +17,11 @@ allow {
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv nlmsg_getneigh };
 
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
+

--- a/prebuilts/api/34.0/public/net.te
+++ b/prebuilts/api/34.0/public/net.te
@@ -14,7 +14,7 @@ allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms
 # Connect to ports.
 allow netdomain port_type:tcp_socket name_connect;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown  };
 
 # Talks to netd via dnsproxyd socket.
 unix_socket_connect(netdomain, dnsproxyd, netd)

--- a/private/net.te
+++ b/private/net.te
@@ -20,6 +20,14 @@ allow {
   -untrusted_app_all
 } self:netlink_route_socket { bind nlmsg_readpriv nlmsg_getneigh };
 
+allow {
+  netdomain
+  -ephemeral_app
+  -mediaprovider
+  -sdk_sandbox_all
+  -untrusted_app_all
+} self:netlink_route_socket nlmsg_read;
+
 ###
 ### Domain with network access
 ###
@@ -31,7 +39,7 @@ allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms
 # Connect to ports.
 allow netdomain port_type:tcp_socket name_connect;
 # See changes to the routing table.
-allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg_read nlmsg };
+allow netdomain self:netlink_route_socket { create read getattr write setattr lock append connect getopt setopt shutdown nlmsg };
 allowxperm netdomain self:netlink_route_socket nlmsg unpriv_route_socket_nlmsgs;
 
 # Talks to netd via dnsproxyd socket.


### PR DESCRIPTION
RTM_GETADDR reveals whether VPN is active. Forbid querying it directly by non-privileged apps

Fixes https://github.com/GrapheneOS/os-issue-tracker/issues/5225