### PR TITLE
Revert "allow vold to securely erase system DE storage encryption key"

### DIFF
--- a/private/vold.te
+++ b/private/vold.te
@@ -150,7 +150,6 @@ allowxperm vold data_file_type:dir ioctl {
 # tried first. Otherwise, FS_IOC_FIEMAP is needed to get the
 # location of the file's blocks on the raw block device to erase.
 allowxperm vold {
-  unencrypted_data_file
   vold_data_file
   vold_metadata_file
   unencrypted_data_file


### PR DESCRIPTION
`allowxperm vold unencrypted_data_file` is upstream since a33b5793bf6bccd2583f22e8a1794b668922b620