### PR TITLE
sepolicy: Add BLE(Bluetooth Low Energy) only mode [4/4]

### DIFF
--- a/private/property_contexts
+++ b/private/property_contexts
@@ -645,6 +645,7 @@ persist.sys.media.avsync                     u:object_r:media_config_prop:s0 exa
 persist.bluetooth.a2dp_offload.cap                          u:object_r:bluetooth_a2dp_offload_prop:s0 exact string
 persist.bluetooth.a2dp_offload.disabled                     u:object_r:bluetooth_a2dp_offload_prop:s0 exact bool
 persist.bluetooth.leaudio_offload.disabled                  u:object_r:bluetooth_a2dp_offload_prop:s0 exact bool
+persist.bluetooth.ble_only                                  u:object_r:bluetooth_prop:s0 exact bool
 persist.bluetooth.bluetooth_audio_hal.disabled              u:object_r:bluetooth_audio_hal_prop:s0 exact bool
 persist.bluetooth.btsnoopenable                             u:object_r:exported_bluetooth_prop:s0 exact bool
 persist.bluetooth.btsnoopdefaultmode                        u:object_r:bluetooth_prop:s0 exact enum empty disabled filtered full


### PR DESCRIPTION
This pull request adds support for a new "BLE only" (Bluetooth Low Energy only) mode in the Bluetooth settings. This feature allows users to restrict Bluetooth functionality to BLE mode for improved security, at the cost of reduced compatibility. 
Part of https://github.com/GrapheneOS/os-issue-tracker/issues/7096